### PR TITLE
Updating `cat` uri to new standards

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,11 +74,7 @@ IPFS.prototype.sendAsync = function sendAsync(opts, cb) {
     try {
       var pinningURI = self.provider.pinning && opts.uri === '/add' ? '?pin=true' : '';
 
-      if (options.payload) {
-        request.open('POST', `${self.requestBase}${opts.uri}${pinningURI}`);
-      } else {
-        request.open('GET', `${self.requestBase}${opts.uri}${pinningURI}`);
-      }
+      request.open('POST', `${self.requestBase}${opts.uri}${pinningURI}`);
 
       if (options.accept) {
         request.setRequestHeader('accept', options.accept);

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ IPFS.prototype.stat = function cat(ipfsHash, callback) {
  */
 IPFS.prototype.cat = function cat(ipfsHash, callback) {
   var self = this;
-  return self.sendAsync({ uri: `/cat/${ipfsHash}` }, callback);
+  return self.sendAsync({ uri: `/cat?arg=${ipfsHash}` }, callback);
 };
 
 /**
@@ -169,5 +169,5 @@ IPFS.prototype.cat = function cat(ipfsHash, callback) {
  */
 IPFS.prototype.catJSON = function catJSON(ipfsHash, callback) {
   var self = this;
-  return self.sendAsync({ uri: `/cat/${ipfsHash}`, jsonParse: true }, callback);
+  return self.sendAsync({ uri: `/cat?arg=${ipfsHash}`, jsonParse: true }, callback);
 };


### PR DESCRIPTION
As mentioned in this [issue](https://github.com/SilentCicero/ipfs-mini/issues/12) a while back, calling the `cat` endpoint as `/api/v0/cat/<cid>` leads to a 405 response and should be updated as `/api/v0/cat?arg=<cid>` as mentioned in the [documentation](https://docs.ipfs.io/reference/http/api/#api-v0-cat).

<details>
<summary>The actual error message</summary>
<br>
[ipfs-mini] status 405: /api/v0/cat/<cid> is an undocumented behavior, use /api/v0/cat?arg=<cid> instead
</details>

Also, it seems as request to the `cat` endpoint is now `POST` and not `GET` anymore.

#### Side note
I didn't spend too much time on this PR and some tests fail or hang but this seems to be because either my setup is wrong or because they are outdated (similar effect on master branch). In any case, `cat` and `catJSON` tests passed successfully.
